### PR TITLE
0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This card is for [Lovelace](https://www.home-assistant.io/lovelace) on [Home Ass
 
 We all use multiple times the same block of configuration across our lovelace configuration and we don't want to change the same things in a hundred places across our configuration each time we want to modify something.
 
-`declutterring-card` to the rescue!! This card allows you to reuse multiple times the same configuration in your lovelace configuration to avoid repetition.
+`declutterring-card` to the rescue!! This card allows you to reuse multiple times the same configuration in your lovelace configuration to avoid repetition and supports variables and default values.
 
 ## Configuration
 
@@ -27,9 +27,23 @@ First, you need to define your templates.
 
 The templates are defined in an object at the root of your lovelace configuration. This object needs to be named `decluttering_templates`.
 
-This object needs to contains your templates declaration, each template has a name and can contain variables. A variable needs to be enclosed in double square brackets `[[variable_name]]`. It will later be replaced by a real value when you instanciate a card which uses this template.
+This object needs to contains your templates declaration, each template has a name and can contain variables. A variable needs to be enclosed in double square brackets `[[variable_name]]`. It will later be replaced by a real value when you instanciate a card which uses this template. If a variable is alone on it's line, enclose it in single quotes: `'[[variable_name]]'`.
 
-Eg in your `lovelace-ui.yaml`:
+You can also define default values for your variables in the `default` object.
+
+```yaml
+decluttering_templates:
+  <template_name>
+    default:  # This is optional
+      - <variable_name>: <variable_value>
+      - <variable_name>: <variable_value>
+      [...]
+    card:  # This is where you put your card config (it can be a card embedding other cards)
+      type: custom:my-super-card
+      [...]
+```
+
+Example in your `lovelace-ui.yaml`:
 ```yaml
 resources:
   - url: /local/decluttering-card.js
@@ -37,19 +51,23 @@ resources:
 
 decluttering_templates:
   my_first_template:     # This is the name of a template
-    type: custom:button-card
-    name: '[[name]]'
-    icon: 'mdi:[[icon]]'
+    default:
+      - icon: fire
+    card:
+      type: custom:button-card
+      name: '[[name]]'
+      icon: 'mdi:[[icon]]'
 
   my_second_template:    # This is the name of another template
-    type: custom:vertical-stack-in-card
-    cards:
-      - type: horizontal-stack
-        cards:
-          - type: custom:button-card
-            entity: '[[entity_1]]'
-          - type: custom:button-card
-            entity: '[[entity_2]]'
+    card:
+      type: custom:vertical-stack-in-card
+      cards:
+        - type: horizontal-stack
+          cards:
+            - type: custom:button-card
+              entity: '[[entity_1]]'
+            - type: custom:button-card
+              entity: '[[entity_2]]'
 ```
 
 ### Using the card
@@ -66,7 +84,11 @@ Example which references the previous templates:
   template: my_first_template
   variables:
     - name: Test Button
-    - icon: fire
+    - icon: arrow-up
+
+- type: custom:decluttering-card
+  template: my_first_template
+  variables: Default Icon Button
 
 - type: custom:decluterring-card
   template: my_second_template

--- a/dist/decluttering-card.js
+++ b/dist/decluttering-card.js
@@ -186,8 +186,12 @@ var e = {},
   if (!e && !t.default) return t.card;let n = [];e && (n = e.slice(0)), t.default && (n = n.concat(t.default));let o = JSON.stringify(t.card);return n.forEach(e => {
     const t = Object.keys(e)[0],
           n = Object.values(e)[0],
-          r = new RegExp(`\\[\\[${t}\\]\\]`, "gm"),
-          i = new RegExp(`"\\[\\[${t}\\]\\]"`, "gm");"number" != typeof n && "boolean" != typeof n || (o = o.replace(i, n)), o = o.replace(r, n);
+          r = new RegExp(`\\[\\[${t}\\]\\]`, "gm");if ("number" == typeof n || "boolean" == typeof n) {
+      const e = new RegExp(`"\\[\\[${t}\\]\\]"`, "gm");o = o.replace(e, n);
+    }if ("object" == typeof n) {
+      const e = new RegExp(`"\\[\\[${t}\\]\\]"`, "gm"),
+            r = JSON.stringify(n);o = o.replace(e, r);
+    } else o = o.replace(r, n);
   }), JSON.parse(o);
 };customElements.define("decluttering-card", class extends HTMLElement {
   constructor() {

--- a/dist/decluttering-card.js
+++ b/dist/decluttering-card.js
@@ -183,25 +183,26 @@ var e = {},
   }return null;
 },
     v = (e, t) => {
-  if (!e) return t;let n = JSON.stringify(t);return e.forEach(e => {
+  if (!e && !t.default) return t;let n = [];e && (n = e.slice(0)), t.default && (n = n.concat(t.default));let o = JSON.stringify(t.card);return n.forEach(e => {
     const t = Object.keys(e)[0],
-          o = Object.values(e)[0],
-          r = new RegExp(`\\[\\[${t}\\]\\]`, "gm");n = n.replace(r, o);
-  }), JSON.parse(n);
+          n = Object.values(e)[0],
+          r = new RegExp(`\\[\\[${t}\\]\\]`, "gm"),
+          i = new RegExp(`"\\[\\[${t}\\]\\]"`, "gm");console.log(`${n}: ${typeof n}`), "number" != typeof n && "boolean" != typeof n || (o = o.replace(i, n)), o = o.replace(r, n);
+  }), JSON.parse(o);
 };customElements.define("decluttering-card", class extends HTMLElement {
   constructor() {
     super(), this.attachShadow({ mode: "open" });
   }set hass(e) {
     this._card && (this._card.hass = e);
   }setConfig(e) {
-    if (!e.template) throw new Error("Missing template object in your config");const t = g();if (!t.config && !t.config.decluttering_templates) throw new Error("The object decluttering_templates doesn't exist in your main lovelace config.");const n = t.config.decluttering_templates[e.template];if (!n) throw new Error(`The template "${e.template}" doesn't exist in decluttering_templates`);const o = this.shadowRoot;for (; o && o.hasChildNodes();) o.removeChild(o.lastChild);const r = document.createElement("div");r.id = "root", o.appendChild(r);const i = (e, t) => {
+    if (!e.template) throw new Error("Missing template object in your config");const t = g();if (!t.config && !t.config.decluttering_templates) throw new Error("The object decluttering_templates doesn't exist in your main lovelace config.");const n = t.config.decluttering_templates[e.template];if (!n || !n.card) throw new Error(`The template "${e.template}" doesn't exist in decluttering_templates`);const o = this.shadowRoot;for (; o && o.hasChildNodes();) o.removeChild(o.lastChild);const r = document.createElement("div");r.id = "root", o.appendChild(r);const i = (e, t) => {
       const n = document.createElement(e);try {
         n.setConfig(t);
       } catch (n) {
         return console.error(e, n), a(n.message, t);
       }return n;
     },
-          a = (e, t) => i("hui-error-card", { type: "error", error: e, config: t });let s = n.type;if (s = s.startsWith("divider") ? "hui-divider-row" : s.startsWith("custom:") ? s.substr("custom:".length) : `hui-${s}-card`, customElements.get(s)) {
+          a = (e, t) => i("hui-error-card", { type: "error", error: e, config: t });let s = n.card.type;if (s = s.startsWith("divider") ? "hui-divider-row" : s.startsWith("custom:") ? s.substr("custom:".length) : `hui-${s}-card`, customElements.get(s)) {
       const t = i(s, v(e.variables, n));r.appendChild(t), this._card = t;
     } else {
       const e = a(`Custom element doesn't exist: ${s}.`, n);e.style.display = "None";const t = setTimeout(() => {

--- a/dist/decluttering-card.js
+++ b/dist/decluttering-card.js
@@ -183,11 +183,11 @@ var e = {},
   }return null;
 },
     v = (e, t) => {
-  if (!e && !t.default) return t;let n = [];e && (n = e.slice(0)), t.default && (n = n.concat(t.default));let o = JSON.stringify(t.card);return n.forEach(e => {
+  if (!e && !t.default) return t.card;let n = [];e && (n = e.slice(0)), t.default && (n = n.concat(t.default));let o = JSON.stringify(t.card);return n.forEach(e => {
     const t = Object.keys(e)[0],
           n = Object.values(e)[0],
           r = new RegExp(`\\[\\[${t}\\]\\]`, "gm"),
-          i = new RegExp(`"\\[\\[${t}\\]\\]"`, "gm");console.log(`${n}: ${typeof n}`), "number" != typeof n && "boolean" != typeof n || (o = o.replace(i, n)), o = o.replace(r, n);
+          i = new RegExp(`"\\[\\[${t}\\]\\]"`, "gm");"number" != typeof n && "boolean" != typeof n || (o = o.replace(i, n)), o = o.replace(r, n);
   }), JSON.parse(o);
 };customElements.define("decluttering-card", class extends HTMLElement {
   constructor() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7317,9 +7317,9 @@
       "optional": true
     },
     "prettier": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.1.tgz",
-      "integrity": "sha512-TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg==",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
       "dev": true
     },
     "private": {
@@ -7845,14 +7845,22 @@
       }
     },
     "rollup": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.12.3.tgz",
-      "integrity": "sha512-ueWhPijWN+GaPgD3l77hXih/gcDXmYph6sWeQegwBYtaqAE834e8u+MC2wT6FKIUsz1DBOyOXAQXUZB+rjWDoQ==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.14.3.tgz",
+      "integrity": "sha512-UZhB6FmipHnSJfjulvM3lrOKuCKTYYkd1pYXzvMsxTbw1eC3SRhPzS1kJU96DT3RZUCOYiFAQYrgcBPRm4E+jw==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "^12.0.2",
+        "@types/node": "^12.0.3",
         "acorn": "^6.1.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.0.7",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.7.tgz",
+          "integrity": "sha512-1YKeT4JitGgE4SOzyB9eMwO0nGVNkNEsm9qlIt1Lqm/tG2QEiSMTD4kS3aO6L+w5SClLVxALmIBESK6Mk5wX0A==",
+          "dev": true
+        }
       }
     },
     "rollup-plugin-babel": {
@@ -9145,9 +9153,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
+      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
       "dev": true
     },
     "typescript-styled-plugin": {

--- a/package.json
+++ b/package.json
@@ -39,15 +39,15 @@
     "eslint-plugin-import": "^2.17.2",
     "npm": "^6.9.0",
     "pre-commit": "^1.2.2",
-    "prettier": "^1.17.1",
-    "rollup": "^1.12.2",
+    "prettier": "^1.18.2",
+    "rollup": "^1.14.3",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-node-resolve": "^4.2.4",
     "rollup-plugin-terser": "^4.0.4",
     "rollup-plugin-typescript2": "^0.20.1",
     "ts-lit-plugin": "^1.0.6",
-    "typescript": "^3.4.4",
+    "typescript": "^3.5.1",
     "typescript-styled-plugin": "^0.14.0"
   },
   "dependencies": {

--- a/src/decluttering-card.ts
+++ b/src/decluttering-card.ts
@@ -1,4 +1,4 @@
-import { DeclutteringCardConfig } from './types';
+import { DeclutteringCardConfig, TemplateConfig } from './types';
 import {
     HomeAssistant,
     getLovelace,
@@ -28,8 +28,8 @@ class DeclutteringCard extends HTMLElement {
         if (!ll.config && !ll.config.decluttering_templates) {
             throw new Error('The object decluttering_templates doesn\'t exist in your main lovelace config.');
         }
-        const cardConfig = ll.config.decluttering_templates[config.template]
-        if (!cardConfig) {
+        const templateConfig = ll.config.decluttering_templates[config.template] as TemplateConfig;
+        if (!templateConfig || !templateConfig.card) {
             throw new Error(`The template "${config.template}" doesn't exist in decluttering_templates`);
         }
 
@@ -83,7 +83,7 @@ class DeclutteringCard extends HTMLElement {
             }
         }
 
-        let tag = cardConfig.type;
+        let tag = templateConfig.card.type;
 
         if (tag.startsWith("divider")) {
             tag = `hui-divider-row`;
@@ -94,14 +94,14 @@ class DeclutteringCard extends HTMLElement {
         }
 
         if (customElements.get(tag)) {
-            const element = _createThing(tag, deepReplace(config.variables, cardConfig));
+            const element = _createThing(tag, deepReplace(config.variables, templateConfig));
             main!.appendChild(element);
             this._card = element;
         } else {
             // If element doesn't exist (yet) create an error
             const element = _createError(
                 `Custom element doesn't exist: ${tag}.`,
-                cardConfig
+                templateConfig
             );
             element.style.display = "None";
 

--- a/src/deep-replace.ts
+++ b/src/deep-replace.ts
@@ -19,11 +19,17 @@ export default (
         const key = Object.keys(variable)[0];
         const value = Object.values(variable)[0];
         const rxp = new RegExp(`\\[\\[${key}\\]\\]`, "gm");
-        const rxp2 = new RegExp(`"\\[\\[${key}\\]\\]"`, "gm");
         if (typeof value === 'number' || typeof value === 'boolean') {
+            const rxp2 = new RegExp(`"\\[\\[${key}\\]\\]"`, "gm");
             jsonConfig = jsonConfig.replace(rxp2, (value as unknown as string));
         }
-        jsonConfig = jsonConfig.replace(rxp, value);
+        if (typeof value === 'object') {
+            const rxp2 = new RegExp(`"\\[\\[${key}\\]\\]"`, "gm");
+            const valueString = JSON.stringify(value);
+            jsonConfig = jsonConfig.replace(rxp2, valueString);
+        } else {
+            jsonConfig = jsonConfig.replace(rxp, value);
+        }
     });
     return JSON.parse(jsonConfig);
 }

--- a/src/deep-replace.ts
+++ b/src/deep-replace.ts
@@ -1,17 +1,29 @@
-import { VariablesConfig } from "./types";
+import { VariablesConfig, TemplateConfig } from "./types";
 
 export default (
     variables: VariablesConfig[] | undefined,
-    cardConfig: any,
+    templateConfig: TemplateConfig,
 ): any => {
-    if (!variables) {
-        return cardConfig;
+    if (!variables && !templateConfig.default) {
+        return templateConfig;
     }
-    let jsonConfig = JSON.stringify(cardConfig);
-    variables.forEach(variable => {
+    let variableArray: VariablesConfig[] = [];
+    if (variables) {
+        variableArray = variables.slice(0);
+    }
+    if (templateConfig.default) {
+        variableArray = variableArray.concat(templateConfig.default);
+    }
+    let jsonConfig = JSON.stringify(templateConfig.card);
+    variableArray.forEach(variable => {
         const key = Object.keys(variable)[0];
         const value = Object.values(variable)[0];
         const rxp = new RegExp(`\\[\\[${key}\\]\\]`, "gm");
+        const rxp2 = new RegExp(`"\\[\\[${key}\\]\\]"`, "gm");
+        console.log(`${value}: ${typeof value}`);
+        if (typeof value === 'number' || typeof value === 'boolean') {
+            jsonConfig = jsonConfig.replace(rxp2, (value as unknown as string));
+        }
         jsonConfig = jsonConfig.replace(rxp, value);
     });
     return JSON.parse(jsonConfig);

--- a/src/deep-replace.ts
+++ b/src/deep-replace.ts
@@ -5,7 +5,7 @@ export default (
     templateConfig: TemplateConfig,
 ): any => {
     if (!variables && !templateConfig.default) {
-        return templateConfig;
+        return templateConfig.card;
     }
     let variableArray: VariablesConfig[] = [];
     if (variables) {
@@ -20,7 +20,6 @@ export default (
         const value = Object.values(variable)[0];
         const rxp = new RegExp(`\\[\\[${key}\\]\\]`, "gm");
         const rxp2 = new RegExp(`"\\[\\[${key}\\]\\]"`, "gm");
-        console.log(`${value}: ${typeof value}`);
         if (typeof value === 'number' || typeof value === 'boolean') {
             jsonConfig = jsonConfig.replace(rxp2, (value as unknown as string));
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,3 +6,8 @@ export interface DeclutteringCardConfig {
 export interface VariablesConfig {
     [key: string]: any;
 }
+
+export interface TemplateConfig {
+    default: VariablesConfig[];
+    card: any;
+}


### PR DESCRIPTION
**BREAKING CHANGES**
* To support default values, I had to change the template format. It has to be defined like this now:
  ```yaml
  decluttering_templates:
    <template_name>
      card:
        <card_config>
  ```
  Instead of
  ```yaml
  decluttering_templates:
    <template_name>
      <card_config>
  ```


**NEW FEATURES**
* Add support for default values (this is optional). If no value is provided for a variable in the actual card, then the default value for that variable will be used (if any). (Fixes #1)
  ```yaml
  <template_name>
    default:
      - variable: default_value
      - variable2: default_value2
      [...]
  ```
* Add support for variables values which are not string (objects, numbers and booleans). Previously they were all converted to string.