### PR TITLE
Create visual editors for decluttering cards and templates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,100 +23,267 @@ We all use multiple times the same block of configuration across our lovelace co
 
 ### Defining your templates
 
-First, you need to define your templates.
+There are two ways to define your templates. You can use both methods together.
 
-The templates are defined in an object at the root of your lovelace configuration. This object needs to be named `decluttering_templates`.
+#### Option 1. Create a template as a card with the visual editor or with YAML.
 
-This object needs to contains your templates declaration, each template has a name and can contain variables. A variable needs to be enclosed in double square brackets `[[variable_name]]`. It will later be replaced by a real value when you instanciate a card which uses this template. If a variable is alone on it's line, enclose it in single quotes: `'[[variable_name]]'`.
+Add a *Custom: Decluttering template* card in any view of your dashboard to define your template,
+set variables with their default values, and preview the results with those defaults with the
+visual editor. The card type is `custom:decluttering-template` in YAML.
 
-You can also define default values for your variables in the `default` object.
+You can place the template card anywhere and it will only visible when the dashboard is in edit mode.
+Each template must have a unique name.
 
-For a card:
+**Example:**
 
 ```yaml
-decluttering_templates:
-  <template_name>
-    default:  # This is optional
-      - <variable_name>: <variable_value>
-      - <variable_name>: <variable_value>
-      [...]
-    card:  # This is where you put your card config (it can be a card embedding other cards)
-      type: custom:my-super-card
-      [...]
+type: custom:decluttering-template
+template: follow_the_sun
+card:
+  type: entity
+  entity_id: sun.sun
 ```
 
-For a Picture-Element:
+#### Option 2. Create a template at the root of your lovelace configuration.
+
+Open your dashboard's YAML configuration file or click on the *Raw configuration editor* menu item
+in the dashboard.
+
+The templates are defined in an object at the root of your lovelace configuration. This object is
+named `decluttering_templates` and it contains your template declarations. Each template must have
+a unique name.
+
+**Example:**
 
 ```yaml
+title: Example Dashboard
 decluttering_templates:
-  <template_name>
-    default:  # This is optional
-      - <variable_name>: <variable_value>
-      - <variable_name>: <variable_value>
-      [...]
-    element:  # This is where you put your element config
+  follow_the_sun:
+    card:
+      type: entity
+      entity_id: sun.sun
+  touch_the_sun:
+    row:
+      type: button
+      entity: sun.sun
+      action_name: Boop
+  hello_sunshine:
+    element:
       type: icon
-      [...]
+      icon: mdi:weather-sunny
+      title: Hello!
+      style:
+        color: yellow
+views:
 ```
 
-Example in your `lovelace-ui.yaml`:
+**Syntax:**
+
 ```yaml
-resources:
-  - url: /local/decluttering-card.js
-    type: module
-
 decluttering_templates:
-  my_first_template:     # This is the name of a template
-    default:
-      - icon: fire
-    card:
-      type: custom:button-card
-      name: '[[name]]'
-      icon: 'mdi:[[icon]]'
+  <template name>:
+    <template content>
+  [...]
+```
 
-  my_second_template:    # This is the name of another template
-    card:
-      type: custom:vertical-stack-in-card
-      cards:
-        - type: horizontal-stack
-          cards:
-            - type: custom:button-card
-              entity: '[[entity_1]]'
-            - type: custom:button-card
-              entity: '[[entity_2]]'
+### Adding content to your templates
+
+You can make decluttering templates for cards, entity rows, and picture elements. Each content type
+has a different syntax and can be used in different places.
+
+#### [Card](https://www.home-assistant.io/dashboards/cards/)
+
+A decluttering template can hold a standard dashboard card, custom card, or another decluttering card.
+It is particularly useful for complex cards such as stacks, grids, and tiles.
+
+**Example:**
+
+```yaml
+type: custom:decluttering-template
+template: follow_the_sun
+card:
+  type: entity
+    entity_id: sun.sun
+```
+
+**Syntax:**
+
+```yaml
+type: custom:decluttering-template
+template: <template_name>
+card:
+  # This is where you put your [Card](https://www.home-assistant.io/dashboards/cards/) configuration (it can be a card embedding other cards)
+  type: <card_type>
+    [...]
+default:
+  # An optional list of variables and their default values to substitute into the template
+  - <variable_name>: <variable_value>
+  - <variable_name>: <variable_value>
+  [...]
+```
+
+#### [Entities card](https://www.home-assistant.io/dashboards/entities/) row
+
+A decluttering template can hold an Entities card row such as a Button row or a Conditional row.
+
+**Example:**
+
+```yaml
+type: custom:decluttering-template
+template: touch_the_sun
+row:
+  type: button
+  entity: sun.sun
+  action_name: Boop
+```
+
+**Syntax:**
+
+```yaml
+type: custom:decluttering-template
+template: <template_name>
+row:
+  # This is where you put your [Entities card](https://www.home-assistant.io/dashboards/entities/) row
+  type: <element_type>
+    [...]
+default:
+  # An optional list of variables and their default values to substitute into the template
+  - <variable_name>: <variable_value>
+  - <variable_name>: <variable_value>
+  [...]
+```
+
+#### [Picture elements card](https://www.home-assistant.io/dashboards/picture-elements/) element
+
+A decluttering template can hold a Picture elements card element such as an Icon or an Image.
+
+**Example:**
+
+```yaml
+type: custom:decluttering-template
+template: hello_sunshine
+element:
+  type: icon
+  icon: mdi:weather-sunny
+  title: Hello!
+  style:
+    color: yellow
+```
+
+**Syntax:**
+
+```yaml
+type: custom:decluttering-template
+template: <template_name>
+element:
+  # This is where you put your [Picture elements card](https://www.home-assistant.io/dashboards/picture-elements/) element configuration
+  type: <element_type>
+    [...]
+default:
+  # An optional list of variables and their default values to substitute into the template
+  - <variable_name>: <variable_value>
+  - <variable_name>: <variable_value>
+  [...]
+```
+
+#### Variables
+
+Templates can contain variables. Each variable will later be replaced by a real value when you
+instantiate a card which uses this template.
+
+A variable needs to be enclosed in double square brackets `[[variable_name]]`. If a variable is alone
+on its line, enclose it in single quotes: `'[[variable_name]]'`.
+
+You can also define default values for your variables in the `default` object. The visual editor uses the
+provided default values to render the preview.
+
+**Example:**
+
+```yaml
+type: custom:decluttering-template
+template: touch_anything
+row:
+  type: button
+  entity: '[[what]]'
+  action_name: '[[how]]'
+default:
+  what: sun.sun
+  how: 'Boop'
 ```
 
 ### Using the card
 
+If your template content is a card, add a *Custom: Decluttering card* to your dashboard
+to instantiate your template, set variables, and preview the results with the visual editor.
+The card type is `custom:decluttering-template` in YAML.
+
+If your template content is an Entities card row, first add a *Entities card* to your dashboard or
+open an existing one. Then switch to the code editor and add a new item to the `entities`
+list in YAML as shown below.
+
+If your template content is an Picture elements card element, first add a *Picture elements* to your
+dashboard or open an existing one. Then switch to the code editor and add a new item to the
+`elements` list in YAML as shown below.
+
+You can also use templates in different places than they were intended. For example, an
+Entities card row or Picture elements card element can be displayed as a card in the dashboard but
+it might not look right.
+
+**Example which references the previous templates:**
+
+```yaml
+type: vertical-stack
+cards:
+  # A card
+  - type: custom:decluttering-card
+    template: follow_the_sun
+  # An Entities card
+  - type: entities
+    entities:
+      # An entity row
+      - type: custom:decluttering-card
+        template: touch_the_sun
+      # An entity row with variables using default values
+      - type: custom:decluttering-card
+        template: touch_anything
+      # An entity row with variables using specified values
+      - type: custom:decluttering-card
+        template: touch_anything
+        variables:
+          - what: sensor.moon_phase
+          - how: 'Kiss'
+  # A Picture elements card
+  - type: picture-elements
+    elements:
+      - type: custom:decluttering-card
+        template: hello_sunshine
+        style:
+          top: 50%
+          left: 33%
+      - type: custom:decluttering-card
+        template: hello_sunshine
+        style:
+          top: 50%
+          left: 66%
+```
+
+**Syntax:**
+
 | Name | Type | Requirement | Description
 | ---- | ---- | ------- | -----------
 | type | string | **Required** | `custom:decluttering-card`
-| template | object | **Required** | The template to use from `decluttering_templates`
-| variables | list | **Optional** | List of variables and their value to replace in the `template`
-
-Example which references the previous templates:
-```yaml
-- type: custom:decluttering-card
-  template: my_first_template
-  variables:
-    - name: Test Button
-    - icon: arrow-up
-
-- type: custom:decluttering-card
-  template: my_first_template
-  variables: Default Icon Button
-
-- type: custom:decluttering-card
-  template: my_second_template
-  variables:
-    - entity_1: switch.my_switch
-    - entity_2: light.my_light
-```
-
+| template | object | **Required** | Name of your template
+| variables | list | **Optional** | List of variables and their values to replace in the template content
 
 ## Installation
 
-### Step 1
+### Using HACS
+
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=custom-cards&repository=decluttering-card&category=lovelace)
+
+### Manually
+
+#### Step 1
 
 Save [decluttering-card](https://github.com/custom-cards/decluttering-card/releases/download/latest/decluttering-card.js) to `<config directory>/www/decluttering-card.js` on your Home Assistant instanse.
 
@@ -127,7 +294,7 @@ wget https://raw.githubusercontent.com/custom-cards/decluttering-card/master/dis
 mv decluttering-card.js /config/www/
 ```
 
-### Step 2
+#### Step 2
 
 Link `decluttering-card` inside your `ui-lovelace.yaml` or Raw Editor in the UI Editor
 
@@ -136,10 +303,6 @@ resources:
   - url: /local/decluttering-card.js
     type: module
 ```
-
-### Step 3
-
-Add a custom element in your `ui-lovelace.yaml` or in the UI Editor as a Manual Card
 
 ## Troubleshooting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "decluttering-card",
-  "version": "0.6.3",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "decluttering-card",
-      "version": "0.6.3",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "custom-card-helpers": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decluttering-card",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "description": "Decluttering Card for Lovelace",
   "main": "dist/decluttering-card.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decluttering-card",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Decluttering Card for Lovelace",
   "main": "dist/decluttering-card.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decluttering-card",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Decluttering Card for Lovelace",
   "main": "dist/decluttering-card.js",
   "scripts": {

--- a/src/decluttering-card.ts
+++ b/src/decluttering-card.ts
@@ -149,10 +149,6 @@ abstract class DeclutteringElement extends LitElement {
       :host(.child-card-hidden) {
         display: none;
       }
-      :host([edit-mode='true']) {
-        display: block !important;
-        border: 1px solid var(--primary-color);
-      }
     `;
   }
 
@@ -391,8 +387,8 @@ class DeclutteringCardEditor extends LitElement implements LovelaceCardEditor {
 @customElement('decluttering-template')
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 class DeclutteringTemplate extends DeclutteringElement {
-  @property({ attribute: 'edit-mode', reflect: true }) editMode;
-  @state() private _previewMode = false;
+  @property({ type: Boolean, reflect: true }) preview = false;
+
   @state() private _template?: string;
 
   static getConfigElement(): HTMLElement {
@@ -417,6 +413,10 @@ class DeclutteringTemplate extends DeclutteringElement {
         margin: 8px;
         color: var(--primary-color);
       }
+      :host([preview]) {
+        display: block !important;
+        border: 1px solid var(--primary-color);
+      }
     `;
   }
 
@@ -428,28 +428,27 @@ class DeclutteringTemplate extends DeclutteringElement {
     this._setTemplateConfig(config, undefined);
   }
 
-  async connectedCallback(): Promise<void> {
-    super.connectedCallback();
-
-    this._previewMode = this.parentElement?.localName === 'hui-card-preview';
-    if (!this.editMode && !this._previewMode) {
-      this.setAttribute('hidden', '');
-    } else {
-      this.removeAttribute('hidden');
-    }
-  }
-
   protected render(): TemplateResult | void {
-    if (this._template) {
-      if (this._previewMode) return super.render();
-      if (this.editMode) {
-        return html`
-          <div class="badge">${this._template}</div>
-          ${super.render()}
-        `;
-      }
+    this.setVisibility(!this.preview);
+    if (this.preview) {
+      return html`
+        <div class="badge">${this._template}</div>
+        ${super.render()}
+      `;
     }
     return html``;
+  }
+
+  private setVisibility(hidden: boolean): void {
+    if (this.hasAttribute('hidden') !== hidden) {
+      this.toggleAttribute('hidden', hidden);
+      this.dispatchEvent(
+        new Event('card-visibility-changed', {
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }
   }
 }
 

--- a/src/decluttering-card.ts
+++ b/src/decluttering-card.ts
@@ -607,32 +607,30 @@ class DeclutteringTemplateEditor extends LitElement implements LovelaceCardEdito
   private _valueChanged(ev: CustomEvent): void {
     if (!this._config) return;
     const data = ev.detail.value;
-
-    this._config.template = data.template;
-    DeclutteringTemplateEditor.stubMember(data.thingType === 'card', this._config, 'card', {
+    const config = { ...this._config, template: data.template, default: data.default };
+    DeclutteringTemplateEditor.stubMember(data.thingType === 'card', config, 'card', {
       type: 'entity',
       entity: 'sun.sun',
     });
-    DeclutteringTemplateEditor.stubMember(data.thingType === 'row', this._config, 'row', {
+    DeclutteringTemplateEditor.stubMember(data.thingType === 'row', config, 'row', {
       entity: 'sun.sun',
     });
-    DeclutteringTemplateEditor.stubMember(data.thingType === 'element', this._config, 'element', {
+    DeclutteringTemplateEditor.stubMember(data.thingType === 'element', config, 'element', {
       type: 'icon',
       icon: 'mdi:weather-sunny',
       style: {
         color: 'yellow',
       },
     });
-    this._config.default = data.default;
-    this._fireConfigChanged();
+    this._fireConfigChanged(config);
   }
 
   private _cardChanged(ev: CustomEvent): void {
     ev.stopPropagation();
     if (!this._config) return;
 
-    this._config.card = ev.detail.config;
-    this._fireConfigChanged();
+    const config = { ...this._config, card: ev.detail.config };
+    this._fireConfigChanged(config);
   }
 
   private _cardPicked(ev: CustomEvent): void {
@@ -644,12 +642,12 @@ class DeclutteringTemplateEditor extends LitElement implements LovelaceCardEdito
     ev.stopPropagation();
     if (!this._config) return;
 
-    this._config.row = ev.detail.config;
-    this._fireConfigChanged();
+    const config = { ...this._config, row: ev.detail.config };
+    this._fireConfigChanged(config);
   }
 
-  private _fireConfigChanged(): void {
-    fireEvent(this, 'config-changed', { config: this._config });
+  private _fireConfigChanged(config: DeclutteringTemplateConfig): void {
+    fireEvent(this, 'config-changed', { config });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/decluttering-card.ts
+++ b/src/decluttering-card.ts
@@ -429,7 +429,7 @@ class DeclutteringTemplate extends DeclutteringElement {
   }
 
   protected render(): TemplateResult | void {
-    this.setVisibility(!this.preview);
+    this.setHidden(!this.preview);
     if (this.preview) {
       return html`
         <div class="badge">${this._template}</div>
@@ -439,7 +439,7 @@ class DeclutteringTemplate extends DeclutteringElement {
     return html``;
   }
 
-  private setVisibility(hidden: boolean): void {
+  private setHidden(hidden: boolean): void {
     if (this.hasAttribute('hidden') !== hidden) {
       this.toggleAttribute('hidden', hidden);
       this.dispatchEvent(

--- a/src/decluttering-card.ts
+++ b/src/decluttering-card.ts
@@ -1,8 +1,16 @@
-import { LitElement, html, customElement, property, TemplateResult, css, CSSResult } from 'lit-element';
-import { HomeAssistant, createThing, LovelaceCardConfig, LovelaceCard } from 'custom-card-helpers';
-import { DeclutteringCardConfig, TemplateConfig } from './types';
+import { LitElement, html, customElement, property, state, TemplateResult, css, CSSResult } from 'lit-element';
+import {
+  HomeAssistant,
+  createThing,
+  fireEvent,
+  LovelaceCardConfig,
+  LovelaceCard,
+  LovelaceCardEditor,
+  LovelaceConfig,
+} from 'custom-card-helpers';
+import { DeclutteringCardConfig, DeclutteringTemplateConfig, TemplateConfig, VariablesConfig } from './types';
 import deepReplace from './deep-replace';
-import { getLovelace, getLovelaceCast } from './utils';
+import { getLovelaceConfig } from './utils';
 import { ResizeObserver } from 'resize-observer';
 import * as pjson from '../package.json';
 
@@ -15,39 +23,107 @@ console.info(
   'color: white; font-weight: bold; background: dimgray',
 );
 
-@customElement('decluttering-card')
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-class DeclutteringCard extends LitElement {
-  @property() protected _card?: LovelaceCard;
+async function loadCardPicker(): Promise<void> {
+  // Ensure hui-card-element-editor and hui-card-picker are loaded.
+  // They happen to be used by the vertical-stack card editor but there must be a better way?
+  let cls = customElements.get('hui-vertical-stack-card');
+  if (!cls) {
+    (await HELPERS).createCardElement({ type: 'vertical-stack', cards: [] });
+    await customElements.whenDefined('hui-vertical-stack-card');
+    cls = customElements.get('hui-vertical-stack-card');
+  }
+  if (cls) await cls.prototype.constructor.getConfigElement();
+}
 
-  @property() private _config?: LovelaceCardConfig;
+function getTemplateConfig(ll: LovelaceConfig, template: string): TemplateConfig | null {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const templates = (ll as any).decluttering_templates;
+  const config = templates?.[template] as TemplateConfig;
+  if (config) return config;
 
+  if (ll.views) {
+    for (const view of ll.views) {
+      if (view.cards) {
+        for (const card of view.cards) {
+          if (card.type === 'custom:decluttering-template' && card.template === template) {
+            return card as DeclutteringTemplateConfig;
+          }
+        }
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const sections = (view as any).sections;
+      if (sections) {
+        for (const section of sections) {
+          if (section.cards) {
+            for (const card of section.cards) {
+              if (card.type === 'custom:decluttering-template' && card.template === template) {
+                return card as DeclutteringTemplateConfig;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return null;
+}
+
+function getTemplates(ll: LovelaceConfig): Record<string, TemplateConfig> {
+  const templates: Record<string, TemplateConfig> = {};
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dt = (ll as any).decluttering_templates;
+  if (dt) Object.assign(templates, dt);
+
+  if (ll.views) {
+    for (const view of ll.views) {
+      if (view.cards) {
+        for (const card of view.cards) {
+          if (card.type === 'custom:decluttering-template') {
+            templates[card.template] = card as DeclutteringTemplateConfig;
+          }
+        }
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const sections = (view as any).sections;
+      if (sections) {
+        for (const section of sections) {
+          if (section.cards) {
+            for (const card of section.cards) {
+              if (card.type === 'custom:decluttering-template') {
+                templates[card.template] = card as DeclutteringTemplateConfig;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return templates;
+}
+
+class DeclutteringElement extends LitElement {
+  @state() private _hass?: HomeAssistant;
+  @state() private _card?: LovelaceCard;
+
+  private _config?: LovelaceCardConfig;
   private _ro?: ResizeObserver;
-
-  private _hass?: HomeAssistant;
-
-  private _type?: 'element' | 'card';
+  private _savedStyles?: Map<string, [string, string]>;
 
   set hass(hass: HomeAssistant) {
     if (!hass) return;
-    if (!this._hass && hass) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      this._createCard(this._config!, this._type!).then(card => {
-        this._card = card;
-        this._card && this._ro?.observe(this._card);
-        return this._card;
-      });
-    }
     this._hass = hass;
-    if (this._card) {
-      this._card.hass = hass;
-    }
+    if (this._card) this._card.hass = hass;
   }
 
   static get styles(): CSSResult {
     return css`
       :host(.child-card-hidden) {
         display: none;
+      }
+      :host([edit-mode='true']) {
+        display: block !important;
+        border: 1px solid var(--primary-color);
       }
     `;
   }
@@ -66,38 +142,54 @@ class DeclutteringCard extends LitElement {
     }
   }
 
-  public setConfig(config: DeclutteringCardConfig): void {
-    if (!config.template) {
-      throw new Error('Missing template object in your config');
-    }
-    const ll = getLovelace() || getLovelaceCast();
-    if (!ll.config && !ll.config.decluttering_templates) {
-      throw new Error("The object decluttering_templates doesn't exist in your main lovelace config.");
-    }
-    const templateConfig = ll.config.decluttering_templates[config.template] as TemplateConfig;
-    if (!templateConfig) {
-      throw new Error(`The template "${config.template}" doesn't exist in decluttering_templates`);
-    } else if (!(templateConfig.card || templateConfig.element)) {
-      throw new Error('You shoud define either a card or an element in the template');
+  protected _setTemplateConfig(templateConfig: TemplateConfig, variables: VariablesConfig[] | undefined): void {
+    if (!(templateConfig.card || templateConfig.element)) {
+      throw new Error('You should define either a card or an element in the template');
     } else if (templateConfig.card && templateConfig.element) {
-      throw new Error('You can define a card and an element in the template');
+      throw new Error('You cannnot define both a card and an element in the template');
     }
+
+    const type = templateConfig.card ? 'card' : 'element';
+    const config = deepReplace(variables, templateConfig);
+    this._config = config;
+    DeclutteringElement._createCard(config, type, (card: LovelaceCard) => {
+      if (this._config === config) this._setCard(card, templateConfig.element ? config.style : undefined);
+    });
+  }
+
+  private _setCard(card: LovelaceCard, style?: Record<string, string>): void {
+    this._savedStyles?.forEach((v, k) => this.style.setProperty(k, v[0], v[1]));
+    this._savedStyles = undefined;
+
+    if (style) {
+      this._savedStyles = new Map();
+      Object.keys(style).forEach(prop => {
+        this._savedStyles?.set(prop, [this.style.getPropertyValue(prop), this.style.getPropertyPriority(prop)]);
+        this.style.setProperty(prop, style[prop]);
+      });
+    }
+
+    this._card = card;
+    if (this._hass) card.hass = this._hass;
     this._ro = new ResizeObserver(() => {
       this._displayHidden();
     });
-    this._config = deepReplace(config.variables, templateConfig);
-    this._type = templateConfig.card ? 'card' : 'element';
+    this._ro.observe(card);
   }
 
   protected render(): TemplateResult | void {
-    if (!this._hass || !this._card || !this._config) return html``;
+    if (!this._hass || !this._card) return html``;
 
     return html`
       <div id="root">${this._card}</div>
     `;
   }
 
-  private async _createCard(config: LovelaceCardConfig, type: 'element' | 'card'): Promise<LovelaceCard> {
+  private static async _createCard(
+    config: LovelaceCardConfig,
+    type: 'element' | 'card',
+    handler: (card: LovelaceCard) => void,
+  ): Promise<void> {
     let element: LovelaceCard;
     if (HELPERS) {
       if (type === 'card') {
@@ -106,43 +198,343 @@ class DeclutteringCard extends LitElement {
         // fireEvent(element, 'll-rebuild');
       } else {
         element = (await HELPERS).createHuiElement(config);
-        if (config.style) {
-          Object.keys(config.style).forEach(prop => {
-            this.style.setProperty(prop, config.style[prop]);
-          });
-        }
       }
     } else {
       element = createThing(config);
-    }
-    if (this._hass) {
-      element.hass = this._hass;
     }
     element.addEventListener(
       'll-rebuild',
       ev => {
         ev.stopPropagation();
-        this._rebuildCard(element, config, type);
+        DeclutteringElement._createCard(config, type, (card: LovelaceCard) => {
+          element.replaceWith(card);
+          handler(card);
+        });
       },
       { once: true },
     );
     element.id = 'declutter-child';
-    return element;
-  }
-
-  private async _rebuildCard(
-    element: LovelaceCard,
-    config: LovelaceCardConfig,
-    type: 'element' | 'card',
-  ): Promise<void> {
-    const newCard = await this._createCard(config, type);
-    element.replaceWith(newCard);
-    this._card = newCard;
-    this._ro?.observe(this._card);
-    return;
+    handler(element);
   }
 
   public getCardSize(): Promise<number> | number {
     return this._card && typeof this._card.getCardSize === 'function' ? this._card.getCardSize() : 1;
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(window as any).customCards = (window as any).customCards || [];
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(window as any).customCards.push({
+  type: 'decluttering-card',
+  name: 'Decluttering card',
+  preview: false,
+  description: 'Reuse multiple times the same card configuration with variables to declutter your config.',
+});
+
+@customElement('decluttering-card')
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+class DeclutteringCard extends DeclutteringElement {
+  static getConfigElement(): HTMLElement {
+    return document.createElement('decluttering-card-editor');
+  }
+
+  static getStubConfig(): DeclutteringCardConfig {
+    return {
+      type: 'custom:decluttering-card',
+      template: 'follow_the_sun',
+    };
+  }
+
+  public setConfig(config: DeclutteringCardConfig): void {
+    if (!config.template) {
+      throw new Error('Missing template object in your config');
+    }
+    const ll = getLovelaceConfig();
+    if (!ll) {
+      throw new Error('Could not retrieve the lovelace configuration.');
+    }
+    const templateConfig = getTemplateConfig(ll, config.template);
+    if (!templateConfig) {
+      throw new Error(
+        `The template "${config.template}" doesn't exist in decluttering_templates or in a custom:decluttering-template card`,
+      );
+    }
+    this._setTemplateConfig(templateConfig, config.variables);
+  }
+}
+
+@customElement('decluttering-card-editor')
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+class DeclutteringCardEditor extends LitElement implements LovelaceCardEditor {
+  @state() private _lovelace?: LovelaceConfig;
+  @state() private _config?: DeclutteringCardConfig;
+
+  @property() public hass?: HomeAssistant;
+
+  private _templates?: Record<string, TemplateConfig>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private _schema: any;
+  private _loadedElements = false;
+
+  set lovelace(lovelace: LovelaceConfig) {
+    this._lovelace = lovelace;
+    this._templates = undefined;
+    this._schema = undefined;
+  }
+
+  public setConfig(config: DeclutteringCardConfig): void {
+    this._config = config;
+  }
+
+  protected render(): TemplateResult | void {
+    if (!this.hass || !this._lovelace || !this._config) return html``;
+
+    if (!this._templates) this._templates = getTemplates(this._lovelace);
+    if (!this._schema) {
+      this._schema = [
+        {
+          name: 'template',
+          label: 'Template to use',
+          selector: {
+            select: {
+              mode: 'dropdown',
+              sort: true,
+              custom_value: true,
+              options: Object.keys(this._templates),
+            },
+          },
+        },
+        {
+          name: 'variables',
+          label: 'Variables',
+          helper: 'Example: - variable_name: value',
+          selector: { object: {} },
+        },
+      ];
+    }
+
+    const error: Record<string, string | string[]> = {};
+    if (!this._templates[this._config.template]) {
+      error.template = 'No template exists with this name';
+    }
+    if (this._config.variables !== undefined && !Array.isArray(this._config.variables)) {
+      error.variables = 'The list of variables must be an array of key and value pairs';
+    }
+
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${this._config}
+        .schema=${this._schema}
+        .error=${error}
+        .computeLabel=${(s): string => s.label ?? s.name}
+        .computeHelper=${(s): string => s.helper ?? ''}
+        @value-changed=${this._valueChanged}
+      ></ha-form>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    fireEvent(this, 'config-changed', { config: ev.detail.value });
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(window as any).customCards = (window as any).customCards || [];
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(window as any).customCards.push({
+  type: 'decluttering-template',
+  name: 'Decluttering template',
+  preview: false,
+  description: 'Define a reusable template for decluttering cards to instantiate.',
+});
+
+@customElement('decluttering-template')
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+class DeclutteringTemplate extends DeclutteringElement {
+  @property({ attribute: 'edit-mode', reflect: true }) editMode;
+  @state() private _previewMode = false;
+  @state() private _template?: string;
+
+  static getConfigElement(): HTMLElement {
+    return document.createElement('decluttering-template-editor');
+  }
+
+  static getStubConfig(): DeclutteringTemplateConfig {
+    return {
+      type: 'custom:decluttering-template',
+      template: 'follow_the_sun',
+      card: {
+        type: 'entity',
+        entity: 'sun.sun',
+      },
+    };
+  }
+
+  static get styles(): CSSResult {
+    return css`
+      ${DeclutteringElement.styles}
+      .badge {
+        margin: 8px;
+        color: var(--primary-color);
+      }
+    `;
+  }
+
+  public setConfig(config: DeclutteringTemplateConfig): void {
+    if (!config.template) {
+      throw new Error('Missing template property');
+    }
+    this._template = config.template;
+    this._setTemplateConfig(config, undefined);
+  }
+
+  async connectedCallback(): Promise<void> {
+    super.connectedCallback();
+
+    this._previewMode = this.parentElement?.localName === 'hui-card-preview';
+    if (!this.editMode && !this._previewMode) {
+      this.setAttribute('hidden', '');
+    } else {
+      this.removeAttribute('hidden');
+    }
+  }
+
+  protected render(): TemplateResult | void {
+    if (this._template) {
+      if (this._previewMode) return super.render();
+      if (this.editMode) {
+        return html`
+          <div class="badge">${this._template}</div>
+          ${super.render()}
+        `;
+      }
+    }
+    return html``;
+  }
+}
+
+@customElement('decluttering-template-editor')
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+class DeclutteringTemplateEditor extends LitElement implements LovelaceCardEditor {
+  @state() private _config?: DeclutteringTemplateConfig;
+  @state() private _selectedTab = 0;
+
+  @property() public lovelace?: LovelaceConfig;
+  @property() public hass?: HomeAssistant;
+
+  private _loadedElements = false;
+
+  private static schema = [
+    {
+      name: 'template',
+      label: 'Template to define',
+      selector: { text: {} },
+    },
+    {
+      name: 'default',
+      label: 'Variables',
+      helper: 'Example: - variable_name: default_value',
+      selector: { object: {} },
+    },
+  ];
+
+  public setConfig(config: DeclutteringTemplateConfig): void {
+    this._config = config;
+  }
+
+  static get styles(): CSSResult {
+    return css`
+      ${DeclutteringElement.styles}
+      .toolbar {
+        display: flex;
+        --paper-tabs-selection-bar-color: var(--primary-color);
+        --paper-tab-ink: var(--primary-color);
+      }
+      paper-tabs {
+        display: flex;
+        font-size: 14px;
+        flex-grow: 1;
+        text-transform: uppercase;
+      }
+    `;
+  }
+
+  async connectedCallback(): Promise<void> {
+    super.connectedCallback();
+
+    if (!this._loadedElements) {
+      await loadCardPicker();
+      this._loadedElements = true;
+    }
+  }
+
+  protected render(): TemplateResult | void {
+    if (!this.hass || !this._config) return html``;
+
+    const error: Record<string, string | string[]> = {};
+    if (this._config.default !== undefined && !Array.isArray(this._config.default)) {
+      error.default = 'The list of variables must be an array of key and value pairs';
+    }
+
+    return html`
+      <div class="toolbar">
+        <paper-tabs .selected=${this._selectedTab} scrollable @iron-activate=${this._activateTab}>
+          <paper-tab>Settings</paper-tab>
+          <paper-tab>Card</paper-tab>
+          <paper-tab>Change Card Type</paper-tab>
+        </paper-tabs>
+      </div>
+      ${this._selectedTab === 0
+        ? html`
+            <ha-form
+              .hass=${this.hass}
+              .data=${this._config}
+              .schema=${DeclutteringTemplateEditor.schema}
+              .error=${error}
+              .computeLabel=${(s): string => s.label ?? s.name}
+              .computeHelper=${(s): string => s.helper ?? ''}
+              @value-changed=${this._valueChanged}
+            ></ha-form>
+          `
+        : this._selectedTab == 1
+        ? html`
+            <hui-card-element-editor
+              .hass=${this.hass}
+              .lovelace=${this.lovelace}
+              .value=${this._config.card}
+              @config-changed=${this._cardChanged}
+            ></hui-card-element-editor>
+          `
+        : html`
+            <hui-card-picker
+              .hass=${this.hass}
+              .lovelace=${this.lovelace}
+              @config-changed=${this._cardPicked}
+            ></hui-card-picker>
+          `}
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    fireEvent(this, 'config-changed', { config: ev.detail.value });
+  }
+
+  private _cardChanged(ev: CustomEvent): void {
+    ev.stopPropagation();
+    if (!this._config) return;
+
+    this._config.card = ev.detail.config;
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+
+  private _cardPicked(ev: CustomEvent): void {
+    this._selectedTab = 1;
+    this._cardChanged(ev);
+  }
+
+  private _activateTab(ev: CustomEvent): void {
+    this._selectedTab = parseInt(ev.detail.selected);
   }
 }

--- a/src/decluttering-card.ts
+++ b/src/decluttering-card.ts
@@ -206,7 +206,7 @@ abstract class DeclutteringElement extends LitElement {
     if (!this._hass || !this._thing) return html``;
 
     return html`
-      <div id="root">${this._thing}</div>
+      ${this._thing}
     `;
   }
 

--- a/src/deep-replace.ts
+++ b/src/deep-replace.ts
@@ -2,8 +2,9 @@ import { VariablesConfig, TemplateConfig } from './types';
 import { LovelaceCardConfig } from 'custom-card-helpers';
 
 export default (variables: VariablesConfig[] | undefined, templateConfig: TemplateConfig): LovelaceCardConfig => {
+  const cardOrElement = templateConfig.card ?? templateConfig.element;
   if (!variables && !templateConfig.default) {
-    return templateConfig.card;
+    return cardOrElement;
   }
   let variableArray: VariablesConfig[] = [];
   if (variables) {
@@ -12,7 +13,7 @@ export default (variables: VariablesConfig[] | undefined, templateConfig: Templa
   if (templateConfig.default) {
     variableArray = variableArray.concat(templateConfig.default);
   }
-  let jsonConfig = templateConfig.card ? JSON.stringify(templateConfig.card) : JSON.stringify(templateConfig.element);
+  let jsonConfig = JSON.stringify(cardOrElement);
   variableArray.forEach(variable => {
     const key = Object.keys(variable)[0];
     const value = Object.values(variable)[0];

--- a/src/deep-replace.ts
+++ b/src/deep-replace.ts
@@ -1,10 +1,9 @@
-import { VariablesConfig, TemplateConfig } from './types';
-import { LovelaceCardConfig } from 'custom-card-helpers';
+import { VariablesConfig, TemplateConfig, LovelaceThingConfig } from './types';
 
-export default (variables: VariablesConfig[] | undefined, templateConfig: TemplateConfig): LovelaceCardConfig => {
-  const cardOrElement = templateConfig.card ?? templateConfig.element;
+export default (variables: VariablesConfig[] | undefined, templateConfig: TemplateConfig): LovelaceThingConfig => {
+  const content = templateConfig.card ?? templateConfig.element ?? templateConfig.row;
   if (!variables && !templateConfig.default) {
-    return cardOrElement;
+    return content;
   }
   let variableArray: VariablesConfig[] = [];
   if (variables) {
@@ -13,7 +12,7 @@ export default (variables: VariablesConfig[] | undefined, templateConfig: Templa
   if (templateConfig.default) {
     variableArray = variableArray.concat(templateConfig.default);
   }
-  let jsonConfig = JSON.stringify(cardOrElement);
+  let jsonConfig = JSON.stringify(content);
   variableArray.forEach(variable => {
     const key = Object.keys(variable)[0];
     const value = Object.values(variable)[0];

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,6 @@ export interface LovelaceElementConfig {
 
 export interface LovelaceRow extends HTMLElement {
   hass?: HomeAssistant;
-  editMode?: boolean;
   setConfig(config: LovelaceRowConfig);
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { LovelaceCardConfig } from 'custom-card-helpers';
+import { HomeAssistant, LovelaceCard, LovelaceCardConfig } from 'custom-card-helpers';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export interface DeclutteringCardConfig extends LovelaceCardConfig {
@@ -17,5 +17,32 @@ export interface VariablesConfig {
 export interface TemplateConfig {
   default?: VariablesConfig[];
   card?: any;
+  row?: any;
   element?: any;
 }
+
+export interface LovelaceElement extends HTMLElement {
+  hass?: HomeAssistant;
+  setConfig(config: LovelaceElementConfig): void;
+}
+
+export interface LovelaceElementConfig {
+  type: string;
+  style: Record<string, string>;
+  [key: string]: any;
+}
+
+export interface LovelaceRow extends HTMLElement {
+  hass?: HomeAssistant;
+  editMode?: boolean;
+  setConfig(config: LovelaceRowConfig);
+}
+
+export interface LovelaceRowConfig {
+  type?: string;
+  [key: string]: any;
+}
+
+export type LovelaceThing = LovelaceCard | LovelaceElement | LovelaceRow;
+export type LovelaceThingConfig = LovelaceCardConfig | LovelaceElementConfig | LovelaceRowConfig;
+export type LovelaceThingType = 'card' | 'row' | 'element';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,12 @@
+import { LovelaceCardConfig } from 'custom-card-helpers';
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export interface DeclutteringCardConfig {
+export interface DeclutteringCardConfig extends LovelaceCardConfig {
   variables?: VariablesConfig[];
+  template: string;
+}
+
+export interface DeclutteringTemplateConfig extends LovelaceCardConfig, TemplateConfig {
   template: string;
 }
 
@@ -9,7 +15,7 @@ export interface VariablesConfig {
 }
 
 export interface TemplateConfig {
-  default: VariablesConfig[];
+  default?: VariablesConfig[];
   card?: any;
   element?: any;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,3 +34,8 @@ export function getLovelace(): LovelaceConfig | null {
   }
   return null;
 }
+
+export function getLovelaceConfig(): LovelaceConfig | null {
+  const ll = getLovelace() || getLovelaceCast();
+  return ll?.config;
+}


### PR DESCRIPTION
The new 'custom:decluttering-template' card declares a template. It can be placed in any view of the dashboard and it is only visible in edit mode. Use the visual editor to conveniently create a template, configure the card or element, set variables with their default values, and preview the results.

The existing 'custom:decluttering-card' card now searches for templates declared by 'custom:decluttering-template' cards in addition to those in the traditional decluttering_templates dashboard configuration. Use the visual editor to conveniently pick an existing template defined elsewhere, set variables, and preview the results.

Fixed possible race conditions when cards are loaded and streamlined the logic.

Restored previously set styles when element styles are modified. The element styling behavior is curiously undocumented...?