### PR TITLE
fix: remove "#declutter-child"

### DIFF
--- a/src/decluttering-card.ts
+++ b/src/decluttering-card.ts
@@ -126,7 +126,6 @@ class DeclutteringCard extends LitElement {
       },
       { once: true },
     );
-    element.id = 'declutter-child';
     return element;
   }
 


### PR DESCRIPTION
Fixes https://github.com/custom-cards/decluttering-card/issues/55
Currently `decluttering-card` forcingly sets an `id` for a child card which may override a default behaviour of a child card.
Example - `min-graph-card`.