### PR TITLE
fix: set height: 100% for "#root"

### DIFF
--- a/src/decluttering-card.ts
+++ b/src/decluttering-card.ts
@@ -49,7 +49,9 @@ class DeclutteringCard extends LitElement {
       :host(.child-card-hidden) {
         display: none;
       }
-    `;
+      #root {
+        height: 100%;
+      }`;
   }
 
   protected firstUpdated(): void {


### PR DESCRIPTION
Fix behaviour in `horizontal-stack` & `grid` cards.

Before:
![изображение](https://github.com/user-attachments/assets/42492373-72a9-4e3f-8b52-5f852f1440ef)

After:
![изображение](https://github.com/user-attachments/assets/f2b1781b-9690-412d-8e4a-c53f9a706252)

